### PR TITLE
Fix systemd unit file

### DIFF
--- a/.github/scripts/generate_release.sh
+++ b/.github/scripts/generate_release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Read stdin
+CURRENT_RELEASE=$(cat -)
+
+# Output 1 if there's no existing release, and increment
+# release number if releases already exist
+if [ "x$CURRENT_RELEASE" == "x" ]; then
+  echo "1"
+else
+  NEW_RELEASE=$(expr $CURRENT_RELEASE + 1)
+  echo "$NEW_RELEASE"
+fi

--- a/.github/workflows/build-and-release-rpm.yaml
+++ b/.github/workflows/build-and-release-rpm.yaml
@@ -24,7 +24,16 @@ jobs:
           fetch-depth: 0
 
       - name: Install Prerequisites
-        run: dnf install -y rpm-build rpmdevtools make git go
+        run: dnf install -y rpm-build rpmdevtools make git go jq curl
+
+      # Query GitHub API for assets under the specified release-tag
+      - name: Generate release number
+        id: release
+        run: |
+          RELEASE=$(curl -fSsL https://api.github.com/repos/${{ github.repository }}/releases |\
+          jq '.[] | select(.name == "${{ github.event.inputs.release-tag }}") | [.assets[].name | select(test(".*\\.rpm$"))] | length' |\
+          .github/scripts/generate_release.sh)
+          echo "::set-output name=release::$RELEASE"
 
       - name: Prepare RPMBUILD Environment
         run: |
@@ -38,8 +47,8 @@ jobs:
       - name: Build RPM
         run: |
           cd ~/rpmbuild || exit 1
-          spectool -g -R --define '_version ${{ github.event.inputs.release-tag }}' SPECS/prometheus-slurm-exporter.spec
-          rpmbuild -bb --define '_version ${{ github.event.inputs.release-tag }}' SPECS/prometheus-slurm-exporter.spec
+          spectool -g -R --define '_release ${{ steps.release.outputs.release }}' --define '_version ${{ github.event.inputs.release-tag }}' SPECS/prometheus-slurm-exporter.spec
+          rpmbuild -bb --define '_release ${{ steps.release.outputs.release }}' --define '_version ${{ github.event.inputs.release-tag }}' SPECS/prometheus-slurm-exporter.spec
 
       - name: Move RPM
         run: |

--- a/lib/systemd/prometheus-slurm-exporter.service
+++ b/lib/systemd/prometheus-slurm-exporter.service
@@ -2,7 +2,9 @@
 Description=Prometheus SLURM Exporter
 
 [Service]
-ExecStart=/usr/bin/prometheus-slurm-exporter
+User=slurm_exporter
+Group=slurm_exporter
+ExecStart=/usr/bin/prometheus-slurm-exporter --listen-address=0.0.0.0:9341
 Restart=always
 RestartSec=15
 

--- a/packages/rpm-ci/prometheus-slurm-exporter.spec
+++ b/packages/rpm-ci/prometheus-slurm-exporter.spec
@@ -42,7 +42,7 @@ mkdir -vp %{buildroot}
 mkdir -vp %{buildroot}%{_unitdir}/
 mkdir -vp %{buildroot}/usr/bin
 mkdir -vp %{buildroot}/usr/share/doc/%{name}-%{version}
-mkdir -vp %{buildroot}/var/lib/prometheus
+mkdir -vp %{buildroot}/var/lib/slurm_exporter
 install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/%{name}.service
 install -m 644 %{SOURCE2} %{buildroot}/usr/share/doc/%{name}-%{version}/LICENSE
 install -m 644 %{SOURCE3} %{buildroot}/usr/share/doc/%{name}-%{version}/README.md
@@ -52,10 +52,10 @@ install -m 755 %{SOURCE4} %{buildroot}/usr/bin/%{name}
 rm -rf %{buildroot}
  
 %pre
-getent group prometheus >/dev/null || groupadd -r prometheus
-getent passwd prometheus >/dev/null || \
-    useradd -r -g prometheus -d /var/lib/slurm_exporter -s /sbin/nologin \
-    -c "Prometheus exporter user" prometheus
+getent group slurm_exporter >/dev/null || groupadd -r slurm_exporter
+getent passwd slurm_exporter >/dev/null || \
+    useradd -r -g slurm_exporter -d /var/lib/slurm_exporter -s /sbin/nologin \
+    -c "Prometheus Slurm exporter user" slurm_exporter
 exit 0
 
 %post
@@ -63,6 +63,7 @@ exit 0
 
 %preun
 %systemd_preun %{name}.service
+userdel slurm_exporter
 
 %postun
 %systemd_postun_with_restart %{name}.service
@@ -74,5 +75,5 @@ exit 0
 %{_bindir}/%{name}
 /usr/share/doc/%{name}-%{version}/
 %{_unitdir}/%{name}.service
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%attr(755, slurm_exporter, slurm_exporter)/var/lib/slurm_exporter
 

--- a/packages/rpm-ci/prometheus-slurm-exporter.spec
+++ b/packages/rpm-ci/prometheus-slurm-exporter.spec
@@ -63,10 +63,17 @@ exit 0
 
 %preun
 %systemd_preun %{name}.service
-userdel slurm_exporter
 
 %postun
 %systemd_postun_with_restart %{name}.service
+
+# Only remove the slurm_exporter service user
+# when we're uninstalling. 
+# Need to force because there might still be a 
+# process running.
+if [ $1 -eq 0 ]; then
+   userdel --force slurm_exporter 2> /dev/null; true
+fi
 
 %files
 %defattr(-,root,root,-)

--- a/packages/rpm-ci/prometheus-slurm-exporter.spec
+++ b/packages/rpm-ci/prometheus-slurm-exporter.spec
@@ -4,7 +4,7 @@
 
 Name:           prometheus-slurm-exporter
 Version:        %{_version}
-Release:        1%{?dist}
+Release:        %{_release}%{?dist}
 Summary:        Prometheus exporter for SLURM metrics
 Group:          Monitoring
 


### PR DESCRIPTION
Fixes for https://github.com/stackhpc/prometheus-slurm-exporter/issues/2.

- Add `slurm_exporter` user and configure systemd unit to run as that user
- Add `--listen-address=0.0.0.0:9341` to the invocation of `slurm_exporter` in systemd

Think these are sensible defaults - deployment Ansible can always re-write the unit file and create users if needed.